### PR TITLE
regex/guia: fix workarounds for POSIX classes

### DIFF
--- a/regex/guia/modernosos-remendos-precedencia.html
+++ b/regex/guia/modernosos-remendos-precedencia.html
@@ -21,10 +21,10 @@ meta            significado
 <pre>
 classe POSIX    remendo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[[:lower:]]     [a-zà-ú]
-[[:upper:]]     [A-ZÀ-Ú]
-[[:alpha:]]     [A-Za-zÀ-ú]
-[[:alnum:]]     [A-Za-zÀ-ú0-9]
+[[:lower:]]     [a-zà-öø-ÿ]
+[[:upper:]]     [A-ZÀ-ÖØ-ß]
+[[:alpha:]]     [A-Za-zÀ-ÖØ-ßà-öø-ÿ]
+[[:alnum:]]     [A-Za-zÀ-ÖØ-ßà-öø-ÿ0-9]
 </pre>
 
 <pre>


### PR DESCRIPTION
The previous workarounds left out `[ûüýþÿ]`, and included `[×÷]`.

Compare:
- [`[a-zà-ú]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[a-z%C3%A0-%C3%BA]) vs [`[a-zà-öø-ÿ]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[a-z%C3%A0-%C3%B6%C3%B8-%C3%BF])
- [`[A-ZÀ-Ú]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[A-Z%C3%80-%C3%9A]) vs [`[A-ZÀ-ÖØ-ß]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[A-Z%C3%80-%C3%96%C3%98-%C3%9F])
- [`[A-Za-zÀ-ú]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[A-Za-z%C3%80-%C3%BA]) vs [`[A-Za-zÀ-ÖØ-ßà-öø-ÿ]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[A-Za-z%C3%80-%C3%96%C3%98-%C3%9F%C3%A0-%C3%B6%C3%B8-%C3%BF])
- [`[A-Za-zÀ-ú0-9]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[A-Za-z%C3%80-%C3%BA0-9]) vs [`[A-Za-zÀ-ÖØ-ßà-öø-ÿ0-9]`](https://blog.robertelder.org/character-class-visualizer?the_regex=[A-Za-z%C3%80-%C3%96%C3%98-%C3%9F%C3%A0-%C3%B6%C3%B8-%C3%BF0-9])