### PR TITLE
Fix broken link tags <a> (and add CI checks)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,5 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1  # considers the .ruby-version file
       - run: bundle install
+      - run: sudo apt install -y tidy
       - run: make build
       - run: make check

--- a/_includes/aureliohead-en.html
+++ b/_includes/aureliohead-en.html
@@ -2,7 +2,6 @@
 <a class="aureliohead"
 	style="position:fixed; right:5px; bottom:0px;"
 	href="/about.html"
-	title="Aurelio Jargas"
-	alt="Aurelio Jargas"><img
+	title="Aurelio Jargas"><img
 	style="width: 64px; height: 64px;"
 	src="/img/articles/aurelio.png"></a>

--- a/_includes/aureliohead.html
+++ b/_includes/aureliohead.html
@@ -2,6 +2,5 @@
 <a class="aureliohead"
 	style="position:fixed; right:5px; bottom:0px;"
 	href="/"
-	title="Aurelio.net — Organizações Verde Inc.™"
-	alt="Aurelio.net — Organizações Verde Inc.™"><img
+	title="Aurelio.net — Organizações Verde Inc.™"><img
 	src="/img/aureliolga.jpg"></a>

--- a/_scripts/check-site
+++ b/_scripts/check-site
@@ -236,6 +236,12 @@ check_broken_html() {
                 # Any warning related to link tags should be a critical problem
                 grep 'Warning: <a>' |
 
+                # Remove false positives: lots of accented URLs in blog posts
+                grep -v '^_site/blog/20.* Warning: <a> escaping malformed URI reference' |
+
+                # Remove false positives: empty hrefs will be filled by JavaScript
+                grep -E -v '^_site/coisinha/(embriagueitor|engripeitor|miguxeitor)/index.html:.*Warning: <a> attribute "href" lacks value' |
+
                 # tidy tends to repeat some output lines, remove them
                 uniq
         done

--- a/_scripts/check-site
+++ b/_scripts/check-site
@@ -22,6 +22,7 @@ test -d _site || { echo "_site not found"; exit 1; }
 
 all_files=$(_scripts/list-site-files all)
 text_files=$(_scripts/list-site-files text)
+html_files=$(_scripts/list-site-files html)
 css_files=$(_scripts/list-site-files css)
 
 # Search for the {{...}} pattern in repo files
@@ -216,6 +217,30 @@ check_windows_linebreak() {
         grep -F CRLF
 }
 
+# Since I edit some HTML files "by hand" (judge me), try to catch some
+# markup errors - #77
+check_broken_html() {
+    # Is tidy available?
+    tidy -version >/dev/null
+
+    echo "$html_files" |
+        while read file
+        do
+            # Grep tidy stderr for critical warnings/errors (stdout is discarded)
+            _scripts/html-tidy -n "$file" 2>&1 >/dev/null |
+
+                # Insert filename in the line beginning
+                # Gotcha: s/// using space as delimiter to avoid filename chars clashes
+                sed "s ^ $file: " |
+
+                # Any warning related to link tags should be a critical problem
+                grep 'Warning: <a>' |
+
+                # tidy tends to repeat some output lines, remove them
+                uniq
+        done
+}
+
 active_checks="
     check_accidental_liquid_markup
     check_windows_linebreak
@@ -229,6 +254,7 @@ active_checks="
     check_link_to_index_html
     check_link_to_gone
     check_link_to_redirected
+    check_broken_html
 "
 
 for check in $active_checks

--- a/_scripts/html-tidy
+++ b/_scripts/html-tidy
@@ -2,7 +2,7 @@
 # Tidy the informed HTML file.
 # Will preserve Jekyll's Front Matter, if any.
 # Get tidy: http://www.html-tidy.org
-# Install:
+# Local .deb install (if needed):
 #     sudo dpkg -i tidy-*.deb
 #     sudo apt-get install -f
 #

--- a/_scripts/html-tidy
+++ b/_scripts/html-tidy
@@ -5,8 +5,20 @@
 # Install:
 #     sudo dpkg -i tidy-*.deb
 #     sudo apt-get install -f
+#
+# Usage: html-tidy [-n] foo.html
+#
+# Option -n does not update the input file, it
+# dumps the tidied code to stdout.
 
-file="$1"
+if test "$1" = -n
+then
+    dry_run=true
+    file="$2"
+else
+    dry_run=false
+    file="$1"
+fi
 
 # http://api.html-tidy.org/tidy/quickref_5.4.0.html
 config='
@@ -75,7 +87,12 @@ then
   del_front_matter "$file" | tidy_stdin
 else
   cat "$file" | tidy_stdin
-fi > "$file.temp"
-mv "$file.temp" "$file"
-
-echo "Saved $file"
+fi |
+    if $dry_run
+    then
+        cat -
+    else
+        cat - > "$file.temp"
+        mv "$file.temp" "$file"
+        echo "Saved $file"
+    fi

--- a/coisinha/miguxeitor/index.html
+++ b/coisinha/miguxeitor/index.html
@@ -444,7 +444,7 @@
 <div id="content">
 
 	<h1>MiGuXeiToR &copy; &reg; &trade;</h1>
-	<h2>Tradutor Online de Português para <a href="http://desciclo.pedia.ws/wiki/Miguxês">Miguxês/Fofolês</a></h2>
+	<h2>Tradutor Online de Português para <a href="https://desciclo.pedia.ws/wiki/Migux%C3%AAs">Miguxês/Fofolês</a></h2>
 
 	<!-- Facebook Like button -->
 	<div style="padding-top:20px;"><div class="fb-like" data-send="true" data-width="500" data-show-faces="true"></div></div>

--- a/musica/ddd/ativistas/index.html
+++ b/musica/ddd/ativistas/index.html
@@ -175,6 +175,6 @@ indispensável para os fãs do 1-2-3-4.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/bandas.html
+++ b/musica/ddd/bandas.html
@@ -30,48 +30,48 @@
     <br>
   </td>
   <td valign="top">
-    <a href="dumbs/>
+    <a href="dumbs/">
     <font size="5"><b><u>DUMBS</u></b></font></a>
     <font size="5">(curitiba - PR)</font><br>
     
-    <a href="godzilla/>
+    <a href="godzilla/">
     <font size="5"><b><u>GODZILLA</u></b></font></a>
     <font size="5">(mogi mirim - SP)</font><br>
     
-    <a href="impatrioticos/>
+    <a href="impatrioticos/">
     <font size="5"><b><u>IMPATRIÓTICOS</u></b></font></a>
     <font size="5">(são paulo - SP)</font><br>
     
-    <a href="losmox/>
+    <a href="losmox/">
     <font size="5"><b><u>LOS MOX!</u></b></font></a>
     <font size="5">(santiago - CHILE)</font><br>
 	
-    <a href="milhouse/>
+    <a href="milhouse/">
     <font size="5"><b><u>MILHOUSE</u></b></font></a>
     <font size="5">(rio de janeiro - RJ)</font><br>
 
-    <a href="noname/>
+    <a href="noname/">
     <font size="5"><b><u>NO NAME</u></b></font></a>
     <font size="5">(porto alegre - RS)</font><br>
 
-    <a href="nopainnogain/>
+    <a href="nopainnogain/">
     <font size="5"><b><u>NO PAIN NO GAIN</u></b></font></a>
     <font size="5">(taquaritinga - SP)</font><br>
 
-    <a href="scarecrow/>
+    <a href="scarecrow/">
     <font size="5"><b><u>SCARECROW</u></b></font></a>
     <font size="5">(curitiba - PR)</font><br>
 
-    <a href="schnaps/>
+    <a href="schnaps/">
     <font size="5"><b><u>SCHNAPS</u></b></font></a>
     <font size="5">(joinville - SC)</font>
     <b><img src="img/palha.gif" width="16" height="16" alt="&:("></b><br>
     
-    <a href="stn/>
+    <a href="stn/">
     <font size="5"><b><u>STN</u></b></font></a>
     <font size="5">(curitiba - PR)</font><br>
     
-    <a href="wallride/>
+    <a href="wallride/">
     <font size="5"><b><u>WALLRIDE</u></b></font></a>
     <font size="5">(porto alegre - RS)</font>
     <b><img src="img/palha.gif" width="16" height="16" alt="&:("></b><br>
@@ -89,12 +89,12 @@
     <br>
   </td>
   <td valign="top">
-	<a href="undertaker/>
+	<a href="undertaker/">
     <font size="5"><b><u>UNDERTAKER</u></b></font></a>
     <font size="5">(porto alegre - RS)</font>
     <b><img src="img/palha.gif" width="16" height="16" alt="&:("></b><br>
 
-    <a href="imortal/>
+    <a href="imortal/">
     <font size="5"><b><u>IMORTAL</u></b></font></a>
     <font size="5">(brasília - DF)</font><br>
   </td>
@@ -111,24 +111,24 @@
     <br>
   </td>
   <td valign="top">
-    <a href="ativistas/>
+    <a href="ativistas/">
     <font size="5"><b><u>ATIVISTAS</u></b></font></a>
     <font size="5">(são paulo - SP)</font><br>
 	
-    <a href="bulimia/>
+    <a href="bulimia/">
     <font size="5"><b><u>BULIMIA</u></b></font></a>
     <font size="5">(brasília - DF)</font><br>
 	
-	<a href="nocontrol/>
+	<a href="nocontrol/">
     <font size="5"><b><u>NO CONTROL</u></b></font></a>
     <font size="5">(porto alegre - RS)</font>
     <b><img src="img/palha.gif" width="16" height="16" alt="&:("></b><br>
     
-    <a href="stukaslazy/>
+    <a href="stukaslazy/">
     <font size="5"><b><u>STUKAS LAZY</u></b></font></a>
     <font size="5">(curitiba - PR)</font><br>
 
-    <a href="thejerks/>
+    <a href="thejerks/">
     <font size="5"><b><u>THE JERKS</u></b></font></a>
     <font size="5">(curitiba - PR)</font><br>
   </td>
@@ -145,7 +145,7 @@
     <br>
   </td>
   <td valign="top">
-    <a href="leidocao/>
+    <a href="leidocao/">
     <font size="5"><b><u>LEI DO CÃO</u></b></font></a>
     <font size="5">(rio de janeiro - RJ)</font>
   </td>
@@ -162,7 +162,7 @@
     <br>
   </td>
   <td valign="top">
-	<a href="lavajato/>
+	<a href="lavajato/">
     <font size="5"><b><u>LAVA-JATO</u></b></font></a>
     <font size="5">(rio de janeiro - RJ)</font><br>
   </td>
@@ -192,12 +192,12 @@
 -->
 
 <blockquote>
-  <p><a href="negative/>
+  <p><a href="negative/">
   <font size="5"><b><u>NEGATIVE CONTROL</u></b></font></a>
   <font size="5">(são bernardo do campo - SP)</font>
   </p>
   
-  <p><a href="ndn/>
+  <p><a href="ndn/">
   <font size="5"><b><u>NOÇÃO DE NADA</u></b></font></a>
   <font size="5">(rio de janeiro - RJ)</font>
   </p>

--- a/musica/ddd/bulimia/index.html
+++ b/musica/ddd/bulimia/index.html
@@ -37,5 +37,5 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>

--- a/musica/ddd/dumbs/index.html
+++ b/musica/ddd/dumbs/index.html
@@ -177,6 +177,6 @@ existência da banda: shows, shows, shows.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/godzilla/index.html
+++ b/musica/ddd/godzilla/index.html
@@ -154,6 +154,6 @@ muito bem escritas por sinal.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/imortal/index.html
+++ b/musica/ddd/imortal/index.html
@@ -163,6 +163,6 @@ para o punk do que para o heavy "anarquia militar".
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/impatrioticos/index.html
+++ b/musica/ddd/impatrioticos/index.html
@@ -195,6 +195,6 @@ inofensivo. punk de verdade.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/lavajato/index.html
+++ b/musica/ddd/lavajato/index.html
@@ -161,6 +161,6 @@ sair cantarolando os refrões "pegajosos".
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/leidocao/index.html
+++ b/musica/ddd/leidocao/index.html
@@ -193,6 +193,6 @@ pessoal e bem tocado. só ouvindo para conferir.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/losmox/demo1.html
+++ b/musica/ddd/losmox/demo1.html
@@ -205,6 +205,6 @@ fora do chile.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/losmox/demo2.html
+++ b/musica/ddd/losmox/demo2.html
@@ -172,6 +172,6 @@ de fraqueza.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/losmox/demo3.html
+++ b/musica/ddd/losmox/demo3.html
@@ -196,6 +196,6 @@ independente pode gravar material de excelente qualidade.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/losmox/demo4.html
+++ b/musica/ddd/losmox/demo4.html
@@ -178,6 +178,6 @@ de "better off dead" do BAD RELIGION, inesquecível.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/losmox/index.html
+++ b/musica/ddd/losmox/index.html
@@ -42,6 +42,6 @@
 </font>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/milhouse/demo1.html
+++ b/musica/ddd/milhouse/demo1.html
@@ -38,6 +38,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/milhouse/demo2.html
+++ b/musica/ddd/milhouse/demo2.html
@@ -196,6 +196,6 @@ MILHOUSE até dizer chega (será?).
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/milhouse/index.html
+++ b/musica/ddd/milhouse/index.html
@@ -33,6 +33,6 @@
 </font>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/ndn/index.html
+++ b/musica/ddd/ndn/index.html
@@ -82,6 +82,6 @@ nota 10 mesmo.
 <p align="right">aurelio - DDD</p>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/negative/index.html
+++ b/musica/ddd/negative/index.html
@@ -77,6 +77,6 @@ diversificadas e concisas, instrumental impecável e vocal feminino brutal.
 <p align="right">aurelio - DDD</p>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/nocontrol/index.html
+++ b/musica/ddd/nocontrol/index.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/noname/index.html
+++ b/musica/ddd/noname/index.html
@@ -171,6 +171,6 @@ no encarte. mais uma boa surpresa que vem de porto alegre.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/nopainnogain/index.html
+++ b/musica/ddd/nopainnogain/index.html
@@ -169,6 +169,6 @@ política inadequada.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/podium.html
+++ b/musica/ddd/podium.html
@@ -23,17 +23,17 @@
 <table align="center" border="2" cellspacing="4" cellpadding="4">
  <tr>
    <td><img src="img/k7ouro.gif" width="25" height="15" alt="1o"></td>
-   <td><a href="losmox/>LOS MOX!</a> - se me apagó la tele</td>
+   <td><a href="losmox/">LOS MOX!</a> - se me apagó la tele</td>
    <td><b>64</b></td>
  </tr>
  <tr>
    <td><img src="img/k7prata.gif" width="25" height="15" alt="2o"></td>
-   <td><a href="milhouse/>MILHOUSE</a> - learn your love</td>
+   <td><a href="milhouse/">MILHOUSE</a> - learn your love</td>
    <td><b>36</b></td>
  </tr>
  <tr>
    <td><img src="img/k7bronze.gif" width="25" height="15" alt="3o"></td>
-   <td><a href="dumbs/>DUMBS</a> - dumbs</td>
+   <td><a href="dumbs/">DUMBS</a> - dumbs</td>
    <td><b>34</b></td>
  </tr>
 </table>

--- a/musica/ddd/scarecrow/demo1.html
+++ b/musica/ddd/scarecrow/demo1.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/scarecrow/demo2.html
+++ b/musica/ddd/scarecrow/demo2.html
@@ -169,6 +169,6 @@ capinha colorida e com fotos.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/scarecrow/index.html
+++ b/musica/ddd/scarecrow/index.html
@@ -32,6 +32,6 @@
 </font>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/schnaps/index.html
+++ b/musica/ddd/schnaps/index.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/stn/index.html
+++ b/musica/ddd/stn/index.html
@@ -156,6 +156,6 @@ uma demo indispensável aos amantes do estilo.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/stukaslazy/demo1.html
+++ b/musica/ddd/stukaslazy/demo1.html
@@ -194,6 +194,6 @@ preocupa com cachês.  seu estilo se caracteriza com a frase "ramones
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/stukaslazy/demo2.html
+++ b/musica/ddd/stukaslazy/demo2.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/stukaslazy/index.html
+++ b/musica/ddd/stukaslazy/index.html
@@ -33,6 +33,6 @@
 </font>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/thejerks/demo1.html
+++ b/musica/ddd/thejerks/demo1.html
@@ -184,6 +184,6 @@ e às vezes não.
 
 <hr size="6">
 
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/thejerks/demo2.html
+++ b/musica/ddd/thejerks/demo2.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/thejerks/index.html
+++ b/musica/ddd/thejerks/index.html
@@ -33,6 +33,6 @@
 </font>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/undertaker/index.html
+++ b/musica/ddd/undertaker/index.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/musica/ddd/wallride/index.html
+++ b/musica/ddd/wallride/index.html
@@ -35,6 +35,6 @@ esta fita demo não está mais fazendo parte da
 </center>
 
 <hr>
-<a href="/musica/ddd/>Voltar ao início</a>
+<a href="/musica/ddd/">Voltar ao início</a>
 </body></html>
 

--- a/shell/dialog/index.html
+++ b/shell/dialog/index.html
@@ -1904,7 +1904,7 @@ itemhelp_color         = (GREEN,BLACK,ON)
     <a href="http://xdialog.dyns.net">Site oficial</a>
   </li>
   <li>
-    <a href="http://thgodef.nerim.net/xdialog/doc/>Documentação Online</a>
+    <a href="http://thgodef.nerim.net/xdialog/doc/">Documentação Online</a>
   </li>
 </ul>
 

--- a/surf/2006-02-04/index.html
+++ b/surf/2006-02-04/index.html
@@ -48,7 +48,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-05/index.html
+++ b/surf/2006-02-05/index.html
@@ -82,7 +82,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-08/index.html
+++ b/surf/2006-02-08/index.html
@@ -202,7 +202,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-10/index.html
+++ b/surf/2006-02-10/index.html
@@ -60,7 +60,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-11/index.html
+++ b/surf/2006-02-11/index.html
@@ -82,7 +82,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-12/index.html
+++ b/surf/2006-02-12/index.html
@@ -170,7 +170,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-13/index.html
+++ b/surf/2006-02-13/index.html
@@ -114,7 +114,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-14/index.html
+++ b/surf/2006-02-14/index.html
@@ -109,7 +109,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-15/index.html
+++ b/surf/2006-02-15/index.html
@@ -158,7 +158,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-21/index.html
+++ b/surf/2006-02-21/index.html
@@ -92,7 +92,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-22/index.html
+++ b/surf/2006-02-22/index.html
@@ -70,7 +70,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-02-23/index.html
+++ b/surf/2006-02-23/index.html
@@ -126,7 +126,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-01/index.html
+++ b/surf/2006-04-01/index.html
@@ -87,7 +87,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-02/index.html
+++ b/surf/2006-04-02/index.html
@@ -70,7 +70,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-05/index.html
+++ b/surf/2006-04-05/index.html
@@ -104,7 +104,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-06/index.html
+++ b/surf/2006-04-06/index.html
@@ -82,7 +82,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-07/index.html
+++ b/surf/2006-04-07/index.html
@@ -114,7 +114,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-08/index.html
+++ b/surf/2006-04-08/index.html
@@ -87,7 +87,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-09/index.html
+++ b/surf/2006-04-09/index.html
@@ -60,7 +60,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-10/index.html
+++ b/surf/2006-04-10/index.html
@@ -38,7 +38,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-11/index.html
+++ b/surf/2006-04-11/index.html
@@ -121,7 +121,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-23/index.html
+++ b/surf/2006-04-23/index.html
@@ -43,7 +43,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-26/index.html
+++ b/surf/2006-04-26/index.html
@@ -88,7 +88,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-29/index.html
+++ b/surf/2006-04-29/index.html
@@ -60,7 +60,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-04-30/index.html
+++ b/surf/2006-04-30/index.html
@@ -48,7 +48,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>

--- a/surf/2006-05-04/index.html
+++ b/surf/2006-05-04/index.html
@@ -33,7 +33,7 @@
   </table>
 <br><br><font size="3"><b>Dica:</b> Clique na foto para vê-la 
 maior.</font><br><br>
-<p><a href="/surf/>&lt; &lt; Voltar à principal</a></p>
+<p><a href="/surf/">&lt; &lt; Voltar à principal</a></p>
 </div><div class="footer"></div>
  </body>
 </html>


### PR DESCRIPTION
The problem is described in #77 

Here is the fix:

- `_scripts/html-tidy` has a new `-n` option, so it can be used as a checker (instead of a formatter)
- `_scripts/check-site` has a new `check_broken_html` check to detect the original problem and other `<a>`-related problems.
- Offending HTML files detected by the new test were fixed.
- `tidy` is now a requirement, and is installed before running the checks in the CI.